### PR TITLE
refactor: Use hint-based containment for SystemBoundarySymbol

### DIFF
--- a/GALLERY.md
+++ b/GALLERY.md
@@ -183,10 +183,11 @@ Diagram
   .build("System Boundary Example", (el, rel, hint) => {
     const user = el.actor("User")
     const login = el.usecase("Login")
-    const boundary = el.systemBoundary("Auth System", [login])
+    const boundary = el.systemBoundary("Auth System")
 
     rel.associate(user, login)
     hint.horizontal(user, boundary)
+    hint.pack(boundary, [login])
   })
   .render("example/system_boundary_example.svg")
 ```

--- a/example/system_boundary_complex.svg
+++ b/example/system_boundary_complex.svg
@@ -1,11 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" 
-     width="350" 
+     width="730" 
      height="250" 
-     viewBox="0 0 350 250">
+     viewBox="0 0 730 250">
   <rect width="100%" height="100%" fill="white"/>
   
   
+      <g id="systemBoundary_5">
+        <!-- System Boundary Rectangle -->
+        <rect x="0" y="0" width="300" height="200" 
+              fill="#f8f8f8" stroke="#999" stroke-width="2"/>
+        
+        <!-- Label at top -->
+        <text x="10" y="19" 
+              font-size="14" font-family="Arial" font-weight="bold"
+              fill="black">
+          Auth System
+        </text>
+      </g>
+    
+
+      <g id="systemBoundary_6">
+        <!-- System Boundary Rectangle -->
+        <rect x="380" y="0" width="300" height="200" 
+              fill="#f8f8f8" stroke="#999" stroke-width="2"/>
+        
+        <!-- Label at top -->
+        <text x="390" y="19" 
+              font-size="14" font-family="Arial" font-weight="bold"
+              fill="black">
+          Admin System
+        </text>
+      </g>
+    
+
       <g id="actor_0">
         <!-- Head -->
         <circle cx="80" cy="65" r="10" 
@@ -64,11 +92,11 @@
 
       <g id="usecase_2">
         <!-- Ellipse -->
-        <ellipse cx="60" cy="30" rx="60" ry="30" 
+        <ellipse cx="80" cy="80" rx="60" ry="30" 
                  fill="white" stroke="black" stroke-width="2"/>
         
         <!-- Label -->
-        <text x="60" y="35" 
+        <text x="80" y="85" 
               text-anchor="middle" font-size="12" font-family="Arial"
               fill="black">
           Login
@@ -78,11 +106,11 @@
 
       <g id="usecase_3">
         <!-- Ellipse -->
-        <ellipse cx="60" cy="30" rx="60" ry="30" 
+        <ellipse cx="80" cy="80" rx="60" ry="30" 
                  fill="white" stroke="black" stroke-width="2"/>
         
         <!-- Label -->
-        <text x="60" y="35" 
+        <text x="80" y="85" 
               text-anchor="middle" font-size="12" font-family="Arial"
               fill="black">
           Logout
@@ -92,89 +120,15 @@
 
       <g id="usecase_4">
         <!-- Ellipse -->
-        <ellipse cx="60" cy="30" rx="60" ry="30" 
+        <ellipse cx="460" cy="80" rx="60" ry="30" 
                  fill="white" stroke="black" stroke-width="2"/>
         
         <!-- Label -->
-        <text x="60" y="35" 
+        <text x="460" y="85" 
               text-anchor="middle" font-size="12" font-family="Arial"
               fill="black">
           Manage Users
         </text>
-      </g>
-    
-
-      <g id="systemBoundary_5">
-        <!-- System Boundary Rectangle -->
-        <rect x="0" y="0" width="300" height="200" 
-              fill="#f8f8f8" stroke="#999" stroke-width="2"/>
-        
-        <!-- Label at top -->
-        <text x="10" y="19" 
-              font-size="14" font-family="Arial" font-weight="bold"
-              fill="black">
-          Auth System
-        </text>
-
-        <!-- Children -->
-        
-      <g id="usecase_2">
-        <!-- Ellipse -->
-        <ellipse cx="60" cy="30" rx="60" ry="30" 
-                 fill="white" stroke="black" stroke-width="2"/>
-        
-        <!-- Label -->
-        <text x="60" y="35" 
-              text-anchor="middle" font-size="12" font-family="Arial"
-              fill="black">
-          Login
-        </text>
-      </g>
-    
-
-      <g id="usecase_3">
-        <!-- Ellipse -->
-        <ellipse cx="60" cy="30" rx="60" ry="30" 
-                 fill="white" stroke="black" stroke-width="2"/>
-        
-        <!-- Label -->
-        <text x="60" y="35" 
-              text-anchor="middle" font-size="12" font-family="Arial"
-              fill="black">
-          Logout
-        </text>
-      </g>
-    
-      </g>
-    
-
-      <g id="systemBoundary_6">
-        <!-- System Boundary Rectangle -->
-        <rect x="0" y="0" width="300" height="200" 
-              fill="#f8f8f8" stroke="#999" stroke-width="2"/>
-        
-        <!-- Label at top -->
-        <text x="10" y="19" 
-              font-size="14" font-family="Arial" font-weight="bold"
-              fill="black">
-          Admin System
-        </text>
-
-        <!-- Children -->
-        
-      <g id="usecase_4">
-        <!-- Ellipse -->
-        <ellipse cx="60" cy="30" rx="60" ry="30" 
-                 fill="white" stroke="black" stroke-width="2"/>
-        
-        <!-- Label -->
-        <text x="60" y="35" 
-              text-anchor="middle" font-size="12" font-family="Arial"
-              fill="black">
-          Manage Users
-        </text>
-      </g>
-    
       </g>
     
 </svg>

--- a/example/system_boundary_complex.ts
+++ b/example/system_boundary_complex.ts
@@ -9,8 +9,15 @@ Diagram
     const logout = element.usecase("Logout")
     const manage = element.usecase("Manage Users")
     
-    // Create system boundary with multiple children
-    const authSystem = element.systemBoundary("Auth System", [login, logout])
-    const adminSystem = element.systemBoundary("Admin System", [manage])
+    // Create system boundaries
+    const authSystem = element.systemBoundary("Auth System")
+    const adminSystem = element.systemBoundary("Admin System")
+    
+    // Pack use cases into boundaries
+    hint.pack(authSystem, [login, logout])
+    hint.pack(adminSystem, [manage])
+    
+    // Layout boundaries
+    hint.horizontal(authSystem, adminSystem)
   })
   .render("example/system_boundary_complex.svg")

--- a/example/system_boundary_example.svg
+++ b/example/system_boundary_example.svg
@@ -5,10 +5,24 @@
      viewBox="0 0 540 300">
   <rect width="100%" height="100%" fill="white"/>
   
-      <line x1="80" y1="90" x2="60" y2="30"
+      <line x1="80" y1="90" x2="270" y2="130"
             stroke="black" stroke-width="1.5"/>
     
   
+      <g id="systemBoundary_2">
+        <!-- System Boundary Rectangle -->
+        <rect x="190" y="50" width="300" height="200" 
+              fill="#f8f8f8" stroke="#999" stroke-width="2"/>
+        
+        <!-- Label at top -->
+        <text x="200" y="69" 
+              font-size="14" font-family="Arial" font-weight="bold"
+              fill="black">
+          Auth System
+        </text>
+      </g>
+    
+
       <g id="actor_0">
         <!-- Head -->
         <circle cx="80" cy="65" r="10" 
@@ -39,45 +53,15 @@
 
       <g id="usecase_1">
         <!-- Ellipse -->
-        <ellipse cx="60" cy="30" rx="60" ry="30" 
+        <ellipse cx="270" cy="130" rx="60" ry="30" 
                  fill="white" stroke="black" stroke-width="2"/>
         
         <!-- Label -->
-        <text x="60" y="35" 
+        <text x="270" y="135" 
               text-anchor="middle" font-size="12" font-family="Arial"
               fill="black">
           Login
         </text>
-      </g>
-    
-
-      <g id="systemBoundary_2">
-        <!-- System Boundary Rectangle -->
-        <rect x="190" y="50" width="300" height="200" 
-              fill="#f8f8f8" stroke="#999" stroke-width="2"/>
-        
-        <!-- Label at top -->
-        <text x="200" y="69" 
-              font-size="14" font-family="Arial" font-weight="bold"
-              fill="black">
-          Auth System
-        </text>
-
-        <!-- Children -->
-        
-      <g id="usecase_1">
-        <!-- Ellipse -->
-        <ellipse cx="60" cy="30" rx="60" ry="30" 
-                 fill="white" stroke="black" stroke-width="2"/>
-        
-        <!-- Label -->
-        <text x="60" y="35" 
-              text-anchor="middle" font-size="12" font-family="Arial"
-              fill="black">
-          Login
-        </text>
-      </g>
-    
       </g>
     
 </svg>

--- a/example/system_boundary_example.ts
+++ b/example/system_boundary_example.ts
@@ -5,9 +5,10 @@ Diagram
   .build("System Boundary Example", (el, rel, hint) => {
     const user = el.actor("User")
     const login = el.usecase("Login")
-    const boundary = el.systemBoundary("Auth System", [login])
+    const boundary = el.systemBoundary("Auth System")
 
     rel.associate(user, login)
     hint.horizontal(user, boundary)
+    hint.pack(boundary, [login])
   })
   .render("example/system_boundary_example.svg")

--- a/example/system_boundary_simple.svg
+++ b/example/system_boundary_simple.svg
@@ -6,6 +6,20 @@
   <rect width="100%" height="100%" fill="white"/>
   
   
+      <g id="systemBoundary_2">
+        <!-- System Boundary Rectangle -->
+        <rect x="0" y="0" width="300" height="200" 
+              fill="#f8f8f8" stroke="#999" stroke-width="2"/>
+        
+        <!-- Label at top -->
+        <text x="10" y="19" 
+              font-size="14" font-family="Arial" font-weight="bold"
+              fill="black">
+          Auth System
+        </text>
+      </g>
+    
+
       <g id="actor_0">
         <!-- Head -->
         <circle cx="80" cy="65" r="10" 
@@ -36,45 +50,15 @@
 
       <g id="usecase_1">
         <!-- Ellipse -->
-        <ellipse cx="60" cy="30" rx="60" ry="30" 
+        <ellipse cx="80" cy="80" rx="60" ry="30" 
                  fill="white" stroke="black" stroke-width="2"/>
         
         <!-- Label -->
-        <text x="60" y="35" 
+        <text x="80" y="85" 
               text-anchor="middle" font-size="12" font-family="Arial"
               fill="black">
           Login
         </text>
-      </g>
-    
-
-      <g id="systemBoundary_2">
-        <!-- System Boundary Rectangle -->
-        <rect x="0" y="0" width="300" height="200" 
-              fill="#f8f8f8" stroke="#999" stroke-width="2"/>
-        
-        <!-- Label at top -->
-        <text x="10" y="19" 
-              font-size="14" font-family="Arial" font-weight="bold"
-              fill="black">
-          Auth System
-        </text>
-
-        <!-- Children -->
-        
-      <g id="usecase_1">
-        <!-- Ellipse -->
-        <ellipse cx="60" cy="30" rx="60" ry="30" 
-                 fill="white" stroke="black" stroke-width="2"/>
-        
-        <!-- Label -->
-        <text x="60" y="35" 
-              text-anchor="middle" font-size="12" font-family="Arial"
-              fill="black">
-          Login
-        </text>
-      </g>
-    
       </g>
     
 </svg>

--- a/example/system_boundary_simple.ts
+++ b/example/system_boundary_simple.ts
@@ -5,8 +5,8 @@ Diagram
   .build("System Boundary Example", (element, relation, hint) => {
     const user = element.actor("User")
     const login = element.usecase("Login")
-    const boundary = element.systemBoundary("Auth System", [login])
+    const boundary = element.systemBoundary("Auth System")
     
-    // Note: Relations would need to be added when relation support is implemented
+    hint.pack(boundary, [login])
   })
   .render("example/system_boundary_simple.svg")

--- a/src/dsl/element_factory.ts
+++ b/src/dsl/element_factory.ts
@@ -26,15 +26,7 @@ export class ElementFactory {
     return this.create("usecase", label)
   }
 
-  systemBoundary(label: string, children: SymbolId[] = []): SymbolId {
-    const id = this.create("systemBoundary", label)
-    const symbol = this.symbols.find(s => s.id === id)
-    if (symbol && "children" in symbol) {
-      const childSymbols = children.map(childId => 
-        this.symbols.find(s => s.id === childId)
-      ).filter((s): s is SymbolBase => s !== undefined)
-      ;(symbol as any).children = childSymbols
-    }
-    return id
+  systemBoundary(label: string): SymbolId {
+    return this.create("systemBoundary", label)
   }
 }

--- a/src/dsl/hint_factory.ts
+++ b/src/dsl/hint_factory.ts
@@ -2,9 +2,11 @@
 import type { SymbolId } from "../model/types"
 
 export interface LayoutHint {
-  type: "horizontal" | "vertical"
+  type: "horizontal" | "vertical" | "pack"
   symbolIds: SymbolId[]
   gap?: number
+  containerId?: SymbolId
+  childIds?: SymbolId[]
 }
 
 export class HintFactory {
@@ -23,6 +25,15 @@ export class HintFactory {
       type: "vertical",
       symbolIds,
       gap: 50
+    })
+  }
+
+  pack(containerId: SymbolId, childIds: SymbolId[]) {
+    this.hints.push({
+      type: "pack",
+      symbolIds: [],
+      containerId,
+      childIds
     })
   }
 }

--- a/src/layout/layout_solver.ts
+++ b/src/layout/layout_solver.ts
@@ -57,6 +57,8 @@ export class LayoutSolver {
         this.addHorizontalConstraints(hint.symbolIds, hint.gap || 80)
       } else if (hint.type === "vertical") {
         this.addVerticalConstraints(hint.symbolIds, hint.gap || 50)
+      } else if (hint.type === "pack") {
+        this.addPackConstraints(hint.containerId!, hint.childIds!)
       }
     }
 
@@ -120,6 +122,56 @@ export class LayoutSolver {
           new kiwi.Expression(b.x),
           kiwi.Operator.Eq,
           new kiwi.Expression(a.x)
+        )
+      )
+    }
+  }
+
+  private addPackConstraints(containerId: string, childIds: string[]) {
+    const container = this.vars.get(containerId)!
+    const padding = 20
+
+    for (const childId of childIds) {
+      const child = this.vars.get(childId)!
+
+      // Child must be inside container with padding
+      // child.x >= container.x + padding
+      this.solver.addConstraint(
+        new kiwi.Constraint(
+          new kiwi.Expression(child.x),
+          kiwi.Operator.Ge,
+          new kiwi.Expression(container.x, padding),
+          kiwi.Strength.required
+        )
+      )
+
+      // child.y >= container.y + padding + 30 (for label space)
+      this.solver.addConstraint(
+        new kiwi.Constraint(
+          new kiwi.Expression(child.y),
+          kiwi.Operator.Ge,
+          new kiwi.Expression(container.y, 50),
+          kiwi.Strength.required
+        )
+      )
+
+      // child.x + child.width <= container.x + container.width - padding
+      this.solver.addConstraint(
+        new kiwi.Constraint(
+          new kiwi.Expression(child.x, child.width),
+          kiwi.Operator.Le,
+          new kiwi.Expression(container.x, container.width, -padding),
+          kiwi.Strength.required
+        )
+      )
+
+      // child.y + child.height <= container.y + container.height - padding
+      this.solver.addConstraint(
+        new kiwi.Constraint(
+          new kiwi.Expression(child.y, child.height),
+          kiwi.Operator.Le,
+          new kiwi.Expression(container.y, container.height, -padding),
+          kiwi.Strength.required
         )
       )
     }

--- a/src/model/symbols/system_boundary_symbol.ts
+++ b/src/model/symbols/system_boundary_symbol.ts
@@ -2,7 +2,6 @@
 import { SymbolBase } from "../symbol_base"
 
 export class SystemBoundarySymbol extends SymbolBase {
-  children: SymbolBase[] = []
   defaultWidth = 300
   defaultHeight = 200
   background = "#f8f8f8"
@@ -10,10 +9,6 @@ export class SystemBoundarySymbol extends SymbolBase {
 
   getDefaultSize() {
     return { width: this.defaultWidth, height: this.defaultHeight }
-  }
-
-  getLayoutHints() {
-    return this.children.map(c => ({ inside: [this, c] }))
   }
 
   toSVG(): string {
@@ -28,9 +23,6 @@ export class SystemBoundarySymbol extends SymbolBase {
     const fontSize = this.theme?.fontSize.usecase || 14
     const textColor = this.theme?.colors.text || "black"
 
-    // Render children
-    const childrenSVG = this.children.map(child => child.toSVG()).join("\n")
-
     return `
       <g id="${this.id}">
         <!-- System Boundary Rectangle -->
@@ -43,9 +35,6 @@ export class SystemBoundarySymbol extends SymbolBase {
               fill="${textColor}">
           ${this.label}
         </text>
-
-        <!-- Children -->
-        ${childrenSVG}
       </g>
     `
   }

--- a/src/render/svg_renderer.ts
+++ b/src/render/svg_renderer.ts
@@ -16,7 +16,16 @@ export class SvgRenderer {
   }
 
   render(): string {
-    const symbolsSvg = this.symbols.map(s => s.toSVG()).join("\n")
+    // Sort symbols to render boundaries first (in background)
+    const sortedSymbols = [...this.symbols].sort((a, b) => {
+      const aIsBoundary = a.constructor.name === "SystemBoundarySymbol"
+      const bIsBoundary = b.constructor.name === "SystemBoundarySymbol"
+      if (aIsBoundary && !bIsBoundary) return -1
+      if (!aIsBoundary && bIsBoundary) return 1
+      return 0
+    })
+    
+    const symbolsSvg = sortedSymbols.map(s => s.toSVG()).join("\n")
     
     // Create symbol map for relationship rendering
     const symbolMap = new Map<SymbolId, SymbolBase>()


### PR DESCRIPTION
## 概要
SystemBoundarySymbol の実装を、children プロパティベースから hint ベースの含有関係に変更しました。

## 問題
以前の実装では、login ユースケースが boundary の中に正しく配置されていませんでした。

## 解決方法

### 新しい API: `hint.pack()`
```typescript
hint.pack(boundary, [login])
```

### 実装の変更
1. **HintFactory に `pack()` メソッドを追加**
   - 含有関係を表現する新しいヒントタイプ
   
2. **LayoutSolver に pack 制約を実装**
   - Kiwi 制約ソルバーを使用して子要素をコンテナ内に配置
   - padding: 20px（左右上下）
   - 上部に 50px のラベルスペース

3. **SystemBoundarySymbol の簡素化**
   - `children` プロパティを削除
   - `getLayoutHints()` メソッドを削除
   - 矩形とラベルのみをレンダリング

4. **レンダリング順序の修正**
   - SystemBoundarySymbol を最初にレンダリング（背景）
   - 子要素はその上に描画される

5. **すべてのサンプルを更新**
   - `el.systemBoundary(label, children)` → `el.systemBoundary(label)` + `hint.pack()`

## 結果
- ✅ Login ユースケースが境界内に正しく配置される
- ✅ 制約ベースのレイアウトで柔軟な配置が可能
- ✅ 既存の例も正常に動作
- ✅ より明示的で理解しやすい API

## スクリーンショット
`example/system_boundary_example.svg` を確認してください。