### PR TITLE
feat: add CorePlugin with basic shape symbols

### DIFF
--- a/example/basic_shapes.svg
+++ b/example/basic_shapes.svg
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" 
+     width="760" 
+     height="160" 
+     viewBox="0 0 760 160">
+  <rect width="100%" height="100%" fill="white"/>
+  
+      <g id="circle_0">
+        <!-- Circle -->
+        <circle cx="80" cy="80" r="30" 
+                fill="white" 
+                stroke="black" 
+                stroke-width="2"/>
+        
+        <!-- Label -->
+        <text x="80" y="85" 
+              text-anchor="middle" 
+              font-size="12" 
+              font-family="Arial"
+              fill="black">
+          Circle
+        </text>
+      </g>
+    
+
+      <g id="ellipse_1">
+        <!-- Ellipse -->
+        <ellipse cx="250" cy="80" rx="60" ry="30" 
+                 fill="white" 
+                 stroke="black" 
+                 stroke-width="2"/>
+        
+        <!-- Label -->
+        <text x="250" y="85" 
+              text-anchor="middle" 
+              font-size="12" 
+              font-family="Arial"
+              fill="black">
+          Ellipse
+        </text>
+      </g>
+    
+
+      <g id="rectangle_2">
+        <!-- Rectangle -->
+        <rect x="390" y="50" width="120" height="60" 
+              fill="white" 
+              stroke="black" 
+              stroke-width="2"/>
+        
+        <!-- Label -->
+        <text x="450" y="85" 
+              text-anchor="middle" 
+              font-size="12" 
+              font-family="Arial"
+              fill="black">
+          Rectangle
+        </text>
+      </g>
+    
+
+      <g id="roundedRectangle_3">
+        <!-- Rounded Rectangle -->
+        <rect x="590" y="50" width="120" height="60" 
+              rx="10" ry="10"
+              fill="white" 
+              stroke="black" 
+              stroke-width="2"/>
+        
+        <!-- Label -->
+        <text x="650" y="85" 
+              text-anchor="middle" 
+              font-size="12" 
+              font-family="Arial"
+              fill="black">
+          Rounded
+        </text>
+      </g>
+    
+</svg>

--- a/example/basic_shapes.ts
+++ b/example/basic_shapes.ts
@@ -1,0 +1,17 @@
+// example/basic_shapes.ts
+import { Diagram, CorePlugin, DefaultTheme } from "../src/index"
+
+Diagram
+  .use(CorePlugin)
+  .theme(DefaultTheme)
+  .build("Basic Shapes", (el, rel, hint) => {
+    // Basic shapes
+    const circle = el.circle("Circle")
+    const ellipse = el.ellipse("Ellipse")
+    const rectangle = el.rectangle("Rectangle")
+    const roundedRect = el.roundedRectangle("Rounded")
+    
+    // Arrange shapes horizontally
+    hint.arrangeHorizontal(circle, ellipse, rectangle, roundedRect)
+  })
+  .render("example/basic_shapes.svg")

--- a/src/core/theme.ts
+++ b/src/core/theme.ts
@@ -49,6 +49,35 @@ export const DefaultTheme: Theme = {
       strokeWidth: 2,
       textColor: 'black',
       fontSize: 14
+    },
+    // Basic shapes
+    circle: {
+      fillColor: 'white',
+      strokeColor: 'black',
+      strokeWidth: 2,
+      textColor: 'black',
+      fontSize: 12
+    },
+    ellipse: {
+      fillColor: 'white',
+      strokeColor: 'black',
+      strokeWidth: 2,
+      textColor: 'black',
+      fontSize: 12
+    },
+    rectangle: {
+      fillColor: 'white',
+      strokeColor: 'black',
+      strokeWidth: 2,
+      textColor: 'black',
+      fontSize: 12
+    },
+    roundedRectangle: {
+      fillColor: 'white',
+      strokeColor: 'black',
+      strokeWidth: 2,
+      textColor: 'black',
+      fontSize: 12
     }
   }
 }
@@ -75,6 +104,27 @@ export const BlueTheme: Theme = {
       textColor: '#003366'
     },
     systemBoundary: {
+      fillColor: '#e6f3ff',
+      strokeColor: '#0066cc',
+      textColor: '#003366'
+    },
+    // Basic shapes
+    circle: {
+      fillColor: '#e6f3ff',
+      strokeColor: '#0066cc',
+      textColor: '#003366'
+    },
+    ellipse: {
+      fillColor: '#e6f3ff',
+      strokeColor: '#0066cc',
+      textColor: '#003366'
+    },
+    rectangle: {
+      fillColor: '#e6f3ff',
+      strokeColor: '#0066cc',
+      textColor: '#003366'
+    },
+    roundedRectangle: {
       fillColor: '#e6f3ff',
       strokeColor: '#0066cc',
       textColor: '#003366'
@@ -106,6 +156,27 @@ export const DarkTheme: Theme = {
     systemBoundary: {
       fillColor: '#2d2d2d',
       strokeColor: '#808080',
+      textColor: '#d4d4d4'
+    },
+    // Basic shapes
+    circle: {
+      fillColor: '#2d2d2d',
+      strokeColor: '#569cd6',
+      textColor: '#d4d4d4'
+    },
+    ellipse: {
+      fillColor: '#2d2d2d',
+      strokeColor: '#569cd6',
+      textColor: '#d4d4d4'
+    },
+    rectangle: {
+      fillColor: '#2d2d2d',
+      strokeColor: '#569cd6',
+      textColor: '#d4d4d4'
+    },
+    roundedRectangle: {
+      fillColor: '#2d2d2d',
+      strokeColor: '#569cd6',
       textColor: '#d4d4d4'
     }
   }

--- a/src/dsl/element_factory.ts
+++ b/src/dsl/element_factory.ts
@@ -9,7 +9,24 @@ export class ElementFactory {
   constructor(
     private registry: SymbolRegistry,
     private symbols: SymbolBase[]
-  ) {}
+  ) {
+    // Proxyを使って動的にメソッドを生成
+    return new Proxy(this, {
+      get(target, prop: string) {
+        // 既存のメソッド/プロパティがあればそれを返す
+        if (prop in target) {
+          return target[prop as keyof typeof target]
+        }
+        
+        // RegistryにSymbolが登録されていれば動的メソッドを返す
+        if (target.registry.has(prop)) {
+          return (label: string) => target.create(prop, label)
+        }
+        
+        return undefined
+      }
+    })
+  }
 
   create(typeName: string, label: string): SymbolId {
     const id = `${typeName}_${this.counter++}`
@@ -18,6 +35,7 @@ export class ElementFactory {
     return id
   }
 
+  // 後方互換性のため残しておく（UMLPlugin用）
   actor(label: string): SymbolId {
     return this.create("actor", label)
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 // src/index.ts
 export { Diagram } from "./dsl/diagram"
+export { CorePlugin } from "./plugin/core_plugin"
 export { UMLPlugin } from "./plugin/uml_plugin"
 export type { SymbolBase } from "./model/symbol_base"
 export type { KiwumilPlugin } from "./dsl/plugin_manager"

--- a/src/model/symbols/circle_symbol.ts
+++ b/src/model/symbols/circle_symbol.ts
@@ -1,0 +1,48 @@
+// src/model/symbols/circle_symbol.ts
+import { SymbolBase } from "../symbol_base"
+import { getStyleForSymbol } from "../../core/theme"
+
+export class CircleSymbol extends SymbolBase {
+  getDefaultSize() {
+    return { width: 60, height: 60 }
+  }
+
+  toSVG(): string {
+    if (!this.bounds) {
+      throw new Error(`Circle ${this.id} has no bounds`)
+    }
+
+    const { x, y, width, height } = this.bounds
+    const cx = x + width / 2
+    const cy = y + height / 2
+    const r = Math.min(width, height) / 2
+
+    const style = this.theme ? getStyleForSymbol(this.theme, 'circle') : {
+      strokeColor: 'black',
+      strokeWidth: 2,
+      fillColor: 'white',
+      textColor: 'black',
+      fontSize: 12,
+      backgroundColor: 'white'
+    }
+
+    return `
+      <g id="${this.id}">
+        <!-- Circle -->
+        <circle cx="${cx}" cy="${cy}" r="${r}" 
+                fill="${style.fillColor}" 
+                stroke="${style.strokeColor}" 
+                stroke-width="${style.strokeWidth}"/>
+        
+        <!-- Label -->
+        <text x="${cx}" y="${cy + 5}" 
+              text-anchor="middle" 
+              font-size="${style.fontSize}" 
+              font-family="Arial"
+              fill="${style.textColor}">
+          ${this.label}
+        </text>
+      </g>
+    `
+  }
+}

--- a/src/model/symbols/ellipse_symbol.ts
+++ b/src/model/symbols/ellipse_symbol.ts
@@ -1,0 +1,49 @@
+// src/model/symbols/ellipse_symbol.ts
+import { SymbolBase } from "../symbol_base"
+import { getStyleForSymbol } from "../../core/theme"
+
+export class EllipseSymbol extends SymbolBase {
+  getDefaultSize() {
+    return { width: 120, height: 60 }
+  }
+
+  toSVG(): string {
+    if (!this.bounds) {
+      throw new Error(`Ellipse ${this.id} has no bounds`)
+    }
+
+    const { x, y, width, height } = this.bounds
+    const cx = x + width / 2
+    const cy = y + height / 2
+    const rx = width / 2
+    const ry = height / 2
+
+    const style = this.theme ? getStyleForSymbol(this.theme, 'ellipse') : {
+      strokeColor: 'black',
+      strokeWidth: 2,
+      fillColor: 'white',
+      textColor: 'black',
+      fontSize: 12,
+      backgroundColor: 'white'
+    }
+
+    return `
+      <g id="${this.id}">
+        <!-- Ellipse -->
+        <ellipse cx="${cx}" cy="${cy}" rx="${rx}" ry="${ry}" 
+                 fill="${style.fillColor}" 
+                 stroke="${style.strokeColor}" 
+                 stroke-width="${style.strokeWidth}"/>
+        
+        <!-- Label -->
+        <text x="${cx}" y="${cy + 5}" 
+              text-anchor="middle" 
+              font-size="${style.fontSize}" 
+              font-family="Arial"
+              fill="${style.textColor}">
+          ${this.label}
+        </text>
+      </g>
+    `
+  }
+}

--- a/src/model/symbols/rectangle_symbol.ts
+++ b/src/model/symbols/rectangle_symbol.ts
@@ -1,0 +1,47 @@
+// src/model/symbols/rectangle_symbol.ts
+import { SymbolBase } from "../symbol_base"
+import { getStyleForSymbol } from "../../core/theme"
+
+export class RectangleSymbol extends SymbolBase {
+  getDefaultSize() {
+    return { width: 120, height: 60 }
+  }
+
+  toSVG(): string {
+    if (!this.bounds) {
+      throw new Error(`Rectangle ${this.id} has no bounds`)
+    }
+
+    const { x, y, width, height } = this.bounds
+    const cx = x + width / 2
+    const cy = y + height / 2
+
+    const style = this.theme ? getStyleForSymbol(this.theme, 'rectangle') : {
+      strokeColor: 'black',
+      strokeWidth: 2,
+      fillColor: 'white',
+      textColor: 'black',
+      fontSize: 12,
+      backgroundColor: 'white'
+    }
+
+    return `
+      <g id="${this.id}">
+        <!-- Rectangle -->
+        <rect x="${x}" y="${y}" width="${width}" height="${height}" 
+              fill="${style.fillColor}" 
+              stroke="${style.strokeColor}" 
+              stroke-width="${style.strokeWidth}"/>
+        
+        <!-- Label -->
+        <text x="${cx}" y="${cy + 5}" 
+              text-anchor="middle" 
+              font-size="${style.fontSize}" 
+              font-family="Arial"
+              fill="${style.textColor}">
+          ${this.label}
+        </text>
+      </g>
+    `
+  }
+}

--- a/src/model/symbols/rounded_rectangle_symbol.ts
+++ b/src/model/symbols/rounded_rectangle_symbol.ts
@@ -1,0 +1,50 @@
+// src/model/symbols/rounded_rectangle_symbol.ts
+import { SymbolBase } from "../symbol_base"
+import { getStyleForSymbol } from "../../core/theme"
+
+export class RoundedRectangleSymbol extends SymbolBase {
+  getDefaultSize() {
+    return { width: 120, height: 60 }
+  }
+
+  toSVG(): string {
+    if (!this.bounds) {
+      throw new Error(`RoundedRectangle ${this.id} has no bounds`)
+    }
+
+    const { x, y, width, height } = this.bounds
+    const cx = x + width / 2
+    const cy = y + height / 2
+    const rx = 10 // 角丸の半径
+    const ry = 10
+
+    const style = this.theme ? getStyleForSymbol(this.theme, 'roundedRectangle') : {
+      strokeColor: 'black',
+      strokeWidth: 2,
+      fillColor: 'white',
+      textColor: 'black',
+      fontSize: 12,
+      backgroundColor: 'white'
+    }
+
+    return `
+      <g id="${this.id}">
+        <!-- Rounded Rectangle -->
+        <rect x="${x}" y="${y}" width="${width}" height="${height}" 
+              rx="${rx}" ry="${ry}"
+              fill="${style.fillColor}" 
+              stroke="${style.strokeColor}" 
+              stroke-width="${style.strokeWidth}"/>
+        
+        <!-- Label -->
+        <text x="${cx}" y="${cy + 5}" 
+              text-anchor="middle" 
+              font-size="${style.fontSize}" 
+              font-family="Arial"
+              fill="${style.textColor}">
+          ${this.label}
+        </text>
+      </g>
+    `
+  }
+}

--- a/src/plugin/core_plugin.ts
+++ b/src/plugin/core_plugin.ts
@@ -1,0 +1,21 @@
+// src/plugin/core_plugin.ts
+import { CircleSymbol } from "../model/symbols/circle_symbol"
+import { EllipseSymbol } from "../model/symbols/ellipse_symbol"
+import { RectangleSymbol } from "../model/symbols/rectangle_symbol"
+import { RoundedRectangleSymbol } from "../model/symbols/rounded_rectangle_symbol"
+import { KiwumilPlugin } from "../dsl/plugin_manager"
+import { SymbolRegistry } from "../model/symbol_registry"
+import { RelationshipRegistry } from "../model/relationship_registry"
+
+export const CorePlugin: KiwumilPlugin = {
+  name: "CorePlugin",
+  registerSymbols(symbols: SymbolRegistry) {
+    symbols.register("circle", CircleSymbol)
+    symbols.register("ellipse", EllipseSymbol)
+    symbols.register("rectangle", RectangleSymbol)
+    symbols.register("roundedRectangle", RoundedRectangleSymbol)
+  },
+  registerRelationships(relationships: RelationshipRegistry) {
+    // CorePluginでは関係を登録しない
+  }
+}


### PR DESCRIPTION
## 概要
基本図形を提供するCorePluginを追加しました。

## 新機能

### CorePlugin
4つの基本図形を追加：
- ✅ **Circle** - 円
- ✅ **Ellipse** - 楕円
- ✅ **Rectangle** - 矩形
- ✅ **RoundedRectangle** - 角丸矩形

### 使用方法
```typescript
import { Diagram, CorePlugin } from 'kiwumil'

Diagram
  .use(CorePlugin)
  .build("Basic Shapes", (el, rel, hint) => {
    const circle = el.circle("Circle")
    const ellipse = el.ellipse("Ellipse")
    const rectangle = el.rectangle("Rectangle")
    const roundedRect = el.roundedRectangle("Rounded")
    
    hint.arrangeHorizontal(circle, ellipse, rectangle, roundedRect)
  })
  .render("output.svg")
```

## 実装内容

### 新規ファイル
- `src/model/symbols/circle_symbol.ts`
- `src/model/symbols/ellipse_symbol.ts`
- `src/model/symbols/rectangle_symbol.ts`
- `src/model/symbols/rounded_rectangle_symbol.ts`
- `src/plugin/core_plugin.ts`
- `example/basic_shapes.ts` (デモ)

### 機能強化
#### ElementFactory に Proxy 実装
- プラグインが登録したシンボルが自動的にメソッドとして利用可能に
- 手動でメソッドを追加する必要なし
- `el.circle()`, `el.ellipse()` などが動的に生成される

#### テーマサポート
全ての基本図形が3つのテーマに対応：
- DefaultTheme - 白背景・黒枠
- BlueTheme - 青系配色
- DarkTheme - ダークモード配色

## テスト結果
```
✓ 40 pass
✓ 0 fail
✓ 192 expect() calls
```

## 変更ファイル
- 10 files changed
- 403 insertions(+)
- 1 deletion(-)

## サンプル出力
`example/basic_shapes.svg` に4つの基本図形が水平に並んで表示されます。