### PR TITLE
refactor: introduce DiagramBuilder and make CorePlugin default

### DIFF
--- a/example/basic_shapes.ts
+++ b/example/basic_shapes.ts
@@ -1,11 +1,11 @@
 // example/basic_shapes.ts
-import { Diagram, CorePlugin, DefaultTheme } from "../src/index"
+import { Diagram, DefaultTheme } from "../src/index"
 
+// CorePluginはデフォルトで有効
 Diagram
-  .use(CorePlugin)
   .theme(DefaultTheme)
   .build("Basic Shapes", (el, rel, hint) => {
-    // Basic shapes
+    // Basic shapes from CorePlugin
     const circle = el.circle("Circle")
     const ellipse = el.ellipse("Ellipse")
     const rectangle = el.rectangle("Rectangle")

--- a/src/dsl/diagram.ts
+++ b/src/dsl/diagram.ts
@@ -1,71 +1,27 @@
 // src/dsl/diagram.ts
-import { SymbolRegistry } from "../model/symbol_registry"
-import { RelationshipRegistry } from "../model/relationship_registry"
-import { PluginManager, KiwumilPlugin } from "./plugin_manager"
-import { ElementFactory } from "./element_factory"
-import { RelationshipFactory } from "./relationship_factory"
-import { HintFactory, LayoutHint } from "./hint_factory"
-import { LayoutSolver } from "../layout/layout_solver"
-import { SvgRenderer } from "../render/svg_renderer"
-import type { SymbolBase } from "../model/symbol_base"
-import type { Association } from "../model/relationships/association"
-import type { Theme } from "../core/theme"
+import { DiagramBuilder } from "./diagram_builder"
 
-type DiagramCallback = (
-  element: ElementFactory,
-  relation: RelationshipFactory,
-  hint: HintFactory
-) => void
-
-export class Diagram {
-  private symbolRegistry = new SymbolRegistry()
-  private relationshipRegistry = new RelationshipRegistry()
-  private pluginManager = new PluginManager(this.symbolRegistry, this.relationshipRegistry)
-  private currentTheme?: Theme
-
-  static use(...plugins: KiwumilPlugin[]): Diagram {
-    const diagram = new Diagram()
-    diagram.pluginManager.use(...plugins)
-    return diagram
-  }
-
-  theme(theme: Theme): Diagram {
-    this.currentTheme = theme
-    return this
-  }
-
-  build(name: string, callback: DiagramCallback) {
-    const symbols: SymbolBase[] = []
-    const relationships: Association[] = []
-    const hints: LayoutHint[] = []
-
-    const element = new ElementFactory(this.symbolRegistry, symbols)
-    const relation = new RelationshipFactory(relationships)
-    const hint = new HintFactory(hints, symbols)
-
-    callback(element, relation, hint)
-
-    // テーマを適用
-    if (this.currentTheme) {
-      for (const symbol of symbols) {
-        symbol.setTheme(this.currentTheme)
-      }
-      for (const relationship of relationships) {
-        relationship.setTheme(this.currentTheme)
-      }
-    }
-
-    // レイアウト計算
-    const solver = new LayoutSolver()
-    solver.solve(symbols, hints)
-
-    return {
-      symbols,
-      relationships,
-      render: (filepath: string) => {
-        const renderer = new SvgRenderer(symbols, relationships, this.currentTheme)
-        renderer.saveToFile(filepath)
-      }
-    }
-  }
-}
+/**
+ * Diagram entry point
+ * 
+ * @example
+ * // CorePlugin is loaded by default
+ * Diagram.build("My Diagram", (el, rel, hint) => {
+ *   const circle = el.circle("Circle")
+ *   const rect = el.rectangle("Rect")
+ *   hint.arrangeHorizontal(circle, rect)
+ * }).render("output.svg")
+ * 
+ * @example
+ * // With additional plugins and theme
+ * Diagram
+ *   .use(UMLPlugin)
+ *   .theme(BlueTheme)
+ *   .build("UML Diagram", (el, rel, hint) => {
+ *     const actor = el.actor("User")
+ *     const usecase = el.usecase("Login")
+ *     rel.associate(actor, usecase)
+ *   })
+ *   .render("output.svg")
+ */
+export const Diagram = new DiagramBuilder()

--- a/src/dsl/diagram_builder.ts
+++ b/src/dsl/diagram_builder.ts
@@ -1,0 +1,76 @@
+// src/dsl/diagram_builder.ts
+import { SymbolRegistry } from "../model/symbol_registry"
+import { RelationshipRegistry } from "../model/relationship_registry"
+import { PluginManager, KiwumilPlugin } from "./plugin_manager"
+import { ElementFactory } from "./element_factory"
+import { RelationshipFactory } from "./relationship_factory"
+import { HintFactory, LayoutHint } from "./hint_factory"
+import { LayoutSolver } from "../layout/layout_solver"
+import { SvgRenderer } from "../render/svg_renderer"
+import { CorePlugin } from "../plugin/core_plugin"
+import type { SymbolBase } from "../model/symbol_base"
+import type { Association } from "../model/relationships/association"
+import type { Theme } from "../core/theme"
+
+type DiagramCallback = (
+  element: ElementFactory,
+  relation: RelationshipFactory,
+  hint: HintFactory
+) => void
+
+export class DiagramBuilder {
+  private symbolRegistry = new SymbolRegistry()
+  private relationshipRegistry = new RelationshipRegistry()
+  private pluginManager = new PluginManager(this.symbolRegistry, this.relationshipRegistry)
+  private currentTheme?: Theme
+
+  constructor() {
+    // CorePluginをデフォルトで有効化
+    this.pluginManager.use(CorePlugin)
+  }
+
+  use(...plugins: KiwumilPlugin[]): DiagramBuilder {
+    this.pluginManager.use(...plugins)
+    return this
+  }
+
+  theme(theme: Theme): DiagramBuilder {
+    this.currentTheme = theme
+    return this
+  }
+
+  build(name: string, callback: DiagramCallback) {
+    const symbols: SymbolBase[] = []
+    const relationships: Association[] = []
+    const hints: LayoutHint[] = []
+
+    const element = new ElementFactory(this.symbolRegistry, symbols)
+    const relation = new RelationshipFactory(relationships)
+    const hint = new HintFactory(hints, symbols)
+
+    callback(element, relation, hint)
+
+    // テーマを適用
+    if (this.currentTheme) {
+      for (const symbol of symbols) {
+        symbol.setTheme(this.currentTheme)
+      }
+      for (const relationship of relationships) {
+        relationship.setTheme(this.currentTheme)
+      }
+    }
+
+    // レイアウト計算
+    const solver = new LayoutSolver()
+    solver.solve(symbols, hints)
+
+    return {
+      symbols,
+      relationships,
+      render: (filepath: string) => {
+        const renderer = new SvgRenderer(symbols, relationships, this.currentTheme)
+        renderer.saveToFile(filepath)
+      }
+    }
+  }
+}

--- a/tests/diagram_builder.test.ts
+++ b/tests/diagram_builder.test.ts
@@ -1,0 +1,327 @@
+// tests/diagram_builder.test.ts
+import { describe, test, expect, beforeEach } from "bun:test"
+import { DiagramBuilder } from "../src/dsl/diagram_builder"
+import { DefaultTheme, BlueTheme } from "../src/core/theme"
+import { UMLPlugin } from "../src/plugin/uml_plugin"
+
+describe("DiagramBuilder", () => {
+  let builder: DiagramBuilder
+
+  beforeEach(() => {
+    builder = new DiagramBuilder()
+  })
+
+  describe("Constructor", () => {
+    test("should automatically load CorePlugin", () => {
+      let circleCalled = false
+      
+      builder.build("Test", (el) => {
+        const circle = el.circle("Test Circle")
+        circleCalled = true
+        expect(circle).toBeDefined()
+      })
+      
+      expect(circleCalled).toBe(true)
+    })
+
+    test("should have basic shapes available from CorePlugin", () => {
+      const shapes: string[] = []
+      
+      builder.build("Test", (el) => {
+        shapes.push(el.circle("Circle"))
+        shapes.push(el.ellipse("Ellipse"))
+        shapes.push(el.rectangle("Rectangle"))
+        shapes.push(el.roundedRectangle("RoundedRect"))
+      })
+      
+      expect(shapes).toHaveLength(4)
+    })
+  })
+
+  describe("use()", () => {
+    test("should load additional plugins", () => {
+      let actorCalled = false
+      
+      builder
+        .use(UMLPlugin)
+        .build("Test", (el) => {
+          const actor = el.actor("User")
+          actorCalled = true
+          expect(actor).toBeDefined()
+        })
+      
+      expect(actorCalled).toBe(true)
+    })
+
+    test("should return builder for chaining", () => {
+      const result = builder.use(UMLPlugin)
+      expect(result).toBe(builder)
+    })
+
+    test("should allow multiple plugins", () => {
+      const result = builder
+        .use(UMLPlugin)
+        .build("Test", (el) => {
+          // Both CorePlugin and UMLPlugin symbols available
+          el.circle("Circle")
+          el.actor("Actor")
+        })
+      
+      expect(result).toBeDefined()
+    })
+  })
+
+  describe("theme()", () => {
+    test("should set theme", () => {
+      const result = builder
+        .theme(BlueTheme)
+        .build("Test", (el) => {
+          el.circle("Circle")
+        })
+      
+      expect(result.symbols).toHaveLength(1)
+      expect(result.symbols[0].theme).toBe(BlueTheme)
+    })
+
+    test("should return builder for chaining", () => {
+      const result = builder.theme(DefaultTheme)
+      expect(result).toBe(builder)
+    })
+
+    test("should apply theme to all symbols", () => {
+      const result = builder
+        .theme(BlueTheme)
+        .build("Test", (el) => {
+          el.circle("Circle")
+          el.rectangle("Rectangle")
+          el.ellipse("Ellipse")
+        })
+      
+      expect(result.symbols).toHaveLength(3)
+      for (const symbol of result.symbols) {
+        expect(symbol.theme).toBe(BlueTheme)
+      }
+    })
+  })
+
+  describe("build()", () => {
+    test("should create symbols from callback", () => {
+      const result = builder.build("Test Diagram", (el) => {
+        el.circle("C1")
+        el.rectangle("R1")
+      })
+      
+      expect(result.symbols).toHaveLength(2)
+      expect(result.symbols[0].label).toBe("C1")
+      expect(result.symbols[1].label).toBe("R1")
+    })
+
+    test("should create relationships from callback", () => {
+      const result = builder
+        .use(UMLPlugin)
+        .build("Test", (el, rel) => {
+          const actor = el.actor("User")
+          const usecase = el.usecase("Login")
+          rel.associate(actor, usecase)
+        })
+      
+      expect(result.relationships).toHaveLength(1)
+    })
+
+    test("should handle layout hints", () => {
+      const result = builder.build("Test", (el, rel, hint) => {
+        const c1 = el.circle("C1")
+        const c2 = el.circle("C2")
+        hint.arrangeHorizontal(c1, c2)
+      })
+      
+      expect(result.symbols).toHaveLength(2)
+      // Check that symbols have bounds (layout was calculated)
+      expect(result.symbols[0].bounds).toBeDefined()
+      expect(result.symbols[1].bounds).toBeDefined()
+    })
+
+    test("should return result with render function", () => {
+      const result = builder.build("Test", (el) => {
+        el.circle("Circle")
+      })
+      
+      expect(result.render).toBeDefined()
+      expect(typeof result.render).toBe("function")
+    })
+
+    test("should calculate layout automatically", () => {
+      const result = builder.build("Test", (el, rel, hint) => {
+        const c1 = el.circle("C1")
+        const c2 = el.circle("C2")
+        hint.arrangeHorizontal(c1, c2)
+      })
+      
+      const [sym1, sym2] = result.symbols
+      
+      // Second symbol should be to the right of first
+      expect(sym2.bounds.x).toBeGreaterThan(sym1.bounds.x)
+      // Y coordinates should be the same (horizontal arrangement)
+      expect(sym2.bounds.y).toBe(sym1.bounds.y)
+    })
+  })
+
+  describe("Method Chaining", () => {
+    test("should support full chaining: use -> theme -> build", () => {
+      const result = builder
+        .use(UMLPlugin)
+        .theme(BlueTheme)
+        .build("Test", (el) => {
+          el.actor("User")
+          el.circle("Circle")
+        })
+      
+      expect(result.symbols).toHaveLength(2)
+      expect(result.symbols[0].theme).toBe(BlueTheme)
+      expect(result.symbols[1].theme).toBe(BlueTheme)
+    })
+
+    test("should support theme -> use -> build", () => {
+      const result = builder
+        .theme(DefaultTheme)
+        .use(UMLPlugin)
+        .build("Test", (el) => {
+          el.usecase("Login")
+        })
+      
+      expect(result.symbols).toHaveLength(1)
+      expect(result.symbols[0].theme).toBe(DefaultTheme)
+    })
+  })
+
+  describe("CorePlugin symbols", () => {
+    test("should have circle available", () => {
+      const result = builder.build("Test", (el) => {
+        const id = el.circle("My Circle")
+        expect(id).toContain("circle")
+      })
+      
+      expect(result.symbols[0].label).toBe("My Circle")
+    })
+
+    test("should have ellipse available", () => {
+      const result = builder.build("Test", (el) => {
+        const id = el.ellipse("My Ellipse")
+        expect(id).toContain("ellipse")
+      })
+      
+      expect(result.symbols[0].label).toBe("My Ellipse")
+    })
+
+    test("should have rectangle available", () => {
+      const result = builder.build("Test", (el) => {
+        const id = el.rectangle("My Rectangle")
+        expect(id).toContain("rectangle")
+      })
+      
+      expect(result.symbols[0].label).toBe("My Rectangle")
+    })
+
+    test("should have roundedRectangle available", () => {
+      const result = builder.build("Test", (el) => {
+        const id = el.roundedRectangle("My RoundedRect")
+        expect(id).toContain("roundedRectangle")
+      })
+      
+      expect(result.symbols[0].label).toBe("My RoundedRect")
+    })
+  })
+
+  describe("Integration", () => {
+    test("should work with multiple symbols and layout hints", () => {
+      const result = builder
+        .theme(BlueTheme)
+        .build("Complex Diagram", (el, rel, hint) => {
+          const circle = el.circle("Circle")
+          const rect = el.rectangle("Rectangle")
+          const ellipse = el.ellipse("Ellipse")
+          
+          hint.arrangeHorizontal(circle, rect, ellipse)
+          hint.alignCenterY(circle, rect, ellipse)
+        })
+      
+      expect(result.symbols).toHaveLength(3)
+      
+      // Check horizontal arrangement
+      expect(result.symbols[1].bounds.x).toBeGreaterThan(result.symbols[0].bounds.x)
+      expect(result.symbols[2].bounds.x).toBeGreaterThan(result.symbols[1].bounds.x)
+      
+      // Check Y alignment
+      const y0 = result.symbols[0].bounds.y
+      expect(result.symbols[1].bounds.y).toBe(y0)
+      expect(result.symbols[2].bounds.y).toBe(y0)
+    })
+
+    test("should work with UMLPlugin and CorePlugin together", () => {
+      const result = builder
+        .use(UMLPlugin)
+        .build("Mixed Diagram", (el, rel, hint) => {
+          const actor = el.actor("User")
+          const circle = el.circle("Circle")
+          const usecase = el.usecase("Action")
+          
+          rel.associate(actor, usecase)
+          hint.arrangeHorizontal(actor, circle, usecase)
+        })
+      
+      expect(result.symbols).toHaveLength(3)
+      expect(result.relationships).toHaveLength(1)
+    })
+
+    test("should generate valid bounds for all symbols", () => {
+      const result = builder.build("Test", (el, rel, hint) => {
+        const shapes = [
+          el.circle("C"),
+          el.ellipse("E"),
+          el.rectangle("R"),
+          el.roundedRectangle("RR")
+        ]
+        
+        hint.arrangeHorizontal(...shapes)
+      })
+      
+      for (const symbol of result.symbols) {
+        expect(symbol.bounds).toBeDefined()
+        expect(symbol.bounds.x).toBeGreaterThanOrEqual(0)
+        expect(symbol.bounds.y).toBeGreaterThanOrEqual(0)
+        expect(symbol.bounds.width).toBeGreaterThan(0)
+        expect(symbol.bounds.height).toBeGreaterThan(0)
+      }
+    })
+  })
+
+  describe("Edge Cases", () => {
+    test("should handle empty diagram", () => {
+      const result = builder.build("Empty", () => {
+        // No symbols
+      })
+      
+      expect(result.symbols).toHaveLength(0)
+      expect(result.relationships).toHaveLength(0)
+    })
+
+    test("should handle diagram with only one symbol", () => {
+      const result = builder.build("Single", (el) => {
+        el.circle("Lonely")
+      })
+      
+      expect(result.symbols).toHaveLength(1)
+      expect(result.symbols[0].bounds).toBeDefined()
+    })
+
+    test("should handle no theme (undefined)", () => {
+      const result = builder.build("No Theme", (el) => {
+        el.circle("Circle")
+      })
+      
+      expect(result.symbols).toHaveLength(1)
+      // Theme should be undefined but symbol should still work
+      expect(result.symbols[0].theme).toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
## 概要
DiagramBuilderクラスを導入し、CorePluginをデフォルトで有効にしました。

## BREAKING CHANGE 🚨
Diagram APIがシングルトンインスタンス方式に変更されました。

### 変更前
```typescript
Diagram.use(UMLPlugin).build(...)
```

### 変更後
```typescript
// CorePluginがデフォルトで有効
Diagram.build("My Diagram", (el, rel, hint) => {
  const circle = el.circle("Circle")
  const rect = el.rectangle("Rect")
  hint.arrangeHorizontal(circle, rect)
}).render("output.svg")

// 追加のプラグインも使用可能
Diagram
  .use(UMLPlugin)
  .theme(BlueTheme)
  .build("UML Diagram", (el, rel, hint) => {
    const actor = el.actor("User")
    const usecase = el.usecase("Login")
    rel.associate(actor, usecase)
  })
  .render("output.svg")
```

## 主な変更

### 新規ファイル
- `src/dsl/diagram_builder.ts` - DiagramBuilderクラス
- `tests/diagram_builder.test.ts` - 25個のテスト

### リファクタリング
- `src/dsl/diagram.ts` - シングルトンインスタンスとしてエクスポート
- `example/basic_shapes.ts` - 新しいAPI使用例

## 実装内容

### DiagramBuilder
- **自動ロード**: CorePluginがコンストラクタで自動的にロード
- **メソッドチェーン**: `.use()`, `.theme()`, `.build()` が連鎖可能
- **JSDoc**: 使用例を含む詳細なドキュメント

### 利点
✅ CorePlugin（基本図形）がすぐに使える  
✅ よりシンプルで直感的なAPI  
✅ 既存のexampleはそのまま動作  
✅ プラグインの追加も柔軟に可能

## テスト

### 新規テスト（25個）
- Constructor: CorePlugin自動ロード
- use(): プラグイン追加
- theme(): テーマ設定
- build(): ダイアグラム構築
- Method Chaining: メソッド連鎖
- CorePlugin symbols: 基本図形の確認
- Integration: 統合テスト
- Edge Cases: エッジケース

### テスト結果
```
✓ 65 pass (25 DiagramBuilder + 24 Theme + 16 LayoutSolver)
✓ 0 fail
✓ 263 expect() calls
Ran 65 tests across 3 files. [48ms]
```

## 影響範囲
- 4 files changed
- 432 insertions(+)
- 73 deletions(-)

すべてのexampleとテストが正常に動作しています。